### PR TITLE
Ttl support

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -74,6 +74,23 @@ func TestAcceptanceProgrammaticAPIKey_WithProjectID(t *testing.T) {
 
 }
 
+func TestAcceptanceDatabaseUser_WithCustomTTL(t *testing.T) {
+	if !runAcceptanceTests {
+		t.SkipNow()
+	}
+
+	acceptanceTestEnv, err := newAcceptanceTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("add config", acceptanceTestEnv.AddConfig)
+	t.Run("add role with ttl", acceptanceTestEnv.AddRoleWithTTL)
+	t.Run("read database user creds", acceptanceTestEnv.ReadDatabaseUserCreds)
+	t.Run("renew database user creds", acceptanceTestEnv.RenewDatabaseUserCreds)
+	t.Run("revoke database user creds", acceptanceTestEnv.RevokeDatabaseUsersCreds)
+}
+
 func newAcceptanceTestEnv() (*testEnv, error) {
 	ctx := context.Background()
 	conf := &logical.BackendConfig{

--- a/path_credentials.go
+++ b/path_credentials.go
@@ -40,13 +40,28 @@ func (b *Backend) pathCredentialsRead(ctx context.Context, req *logical.Request,
 		return nil, errwrap.Wrapf("error retrieving credential: {{err}}", err)
 	}
 
-	// Get lease configuration(if any)
-	leaseConfig, err := b.LeaseConfig(ctx, req.Storage)
+	defaultLease, err := b.LeaseConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}
-	if leaseConfig == nil {
-		leaseConfig = &configLease{}
+
+	// Get lease configuration
+	leaseConfig := &configLease{}
+
+	if cred.TTL > 0 {
+		leaseConfig.TTL = cred.TTL
+	} else {
+		leaseConfig.TTL = defaultLease.TTL
+	}
+
+	if cred.MaxTTL > 0 {
+		leaseConfig.MaxTTL = cred.MaxTTL
+	} else {
+		leaseConfig.MaxTTL = defaultLease.MaxTTL
+	}
+
+	if leaseConfig.TTL > leaseConfig.MaxTTL {
+		leaseConfig.TTL = leaseConfig.MaxTTL
 	}
 
 	switch cred.CredentialType {

--- a/path_credentials.go
+++ b/path_credentials.go
@@ -46,17 +46,20 @@ func (b *Backend) pathCredentialsRead(ctx context.Context, req *logical.Request,
 	}
 
 	// Get lease configuration
-	leaseConfig := &configLease{}
+	leaseConfig := &configLease{
+		TTL:    0,
+		MaxTTL: 0,
+	}
 
 	if cred.TTL > 0 {
 		leaseConfig.TTL = cred.TTL
-	} else {
+	} else if defaultLease != nil {
 		leaseConfig.TTL = defaultLease.TTL
 	}
 
 	if cred.MaxTTL > 0 {
 		leaseConfig.MaxTTL = cred.MaxTTL
-	} else {
+	} else if defaultLease != nil {
 		leaseConfig.MaxTTL = defaultLease.MaxTTL
 	}
 

--- a/path_roles.go
+++ b/path_roles.go
@@ -274,8 +274,8 @@ func (r atlasCredentialEntry) toResponseData() map[string]interface{} {
 		"roles":                  r.Roles,
 		"programmatic_key_roles": r.ProgrammaticKeyRoles,
 		"organization_id":        r.OrganizationID,
-		"ttl":                    r.TTL,
-		"max_ttl":                r.MaxTTL,
+		"ttl":                    r.TTL.String(),
+		"max_ttl":                r.MaxTTL.String(),
 	}
 	return respData
 }

--- a/path_roles_list.go
+++ b/path_roles_list.go
@@ -38,4 +38,3 @@ func (b *Backend) pathRolesList(ctx context.Context, req *logical.Request, d *fr
 
 const pathRolesListHelpSyn = ``
 const pathRolesListHelpDesc = ``
-

--- a/test_env.go
+++ b/test_env.go
@@ -61,6 +61,30 @@ func (e *testEnv) AddRole(t *testing.T) {
 	// }
 }
 
+func (e *testEnv) AddRoleWithTTL(t *testing.T) {
+	roles := `[{"databaseName":"admin","roleName":"atlasAdmin"}]`
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "roles/test-credential",
+		Storage:   e.Storage,
+		Data: map[string]interface{}{
+			"credential_type": "database_user",
+			"project_id":      e.ProjectID,
+			"database_name":   "admin",
+			"roles":           roles,
+			"ttl":             2000,
+			"max_ttl":         4000,
+		},
+	}
+	resp, err := e.Backend.HandleRequest(e.Context, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: resp: %#v\nerr:%v", resp, err)
+	}
+	// if resp != nil {
+	// 	t.Fatal("expected nil response to represent a 204")
+	// }
+}
+
 func (e *testEnv) ReadDatabaseUserCreds(t *testing.T) {
 	req := &logical.Request{
 		Operation: logical.ReadOperation,


### PR DESCRIPTION
closes #8 

example:
```sh
$ vault write atlas/roles/test \
    name=myApiKey \
    credential_type=org_programmatic_api_key \
    organization_id=5b71ff2f96e82120d0aaec14 \
    programmatic_key_roles=ORG_MEMBER \
    ttl=2h \  
    max_ttl=5h
```
```sh
$ vault read atlas/creds/test 
// expected

Key                Value
---                -----
lease_id           atlas/creds/test/cgP8UmZ
lease_duration     2h
lease_renewable    true
description        vault-test-1565202469-456
private_key        <private-key>
public_key         yawvoldf
``` 

```sh
$ vault read atlas/roles/test
// expected

Key                       Value
---                       -----
credential_type           org_programmatic_api_key
database_name             n/a
max_ttl                   5h0m0s
organization_id           5b71ff2f96e82120d0aaec14
programmatic_key_roles    [ORG_MEMBER]
project_id                n/a
roles                     n/a
ttl                       2h0m0s
```
