### PR TITLE
TTL Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ This plugin generates unique, ephemeral datababase user credentials and programm
 
 **Please note**: Hashicorp takes Vault's security and their users' trust very seriously, as does MongoDB.
 
-If you believe you have found a security issue in Vault or with this plugin, 
-_please responsibly disclose_ by 
+If you believe you have found a security issue in Vault or with this plugin,
+_please responsibly disclose_ by
 contacting us at [security@hashicorp.com](mailto:security@hashicorp.com) and contact MongoDB
 directly via [security@mongodb.com](mailto:security@mongodb.com) or [open a ticket](https://jira.mongodb.org/plugins/servlet/samlsso?redirectTo=%2Fbrowse%2FSECURITY) (link is external).
 
 ## Quick Links
 - [Vault Website](https://www.vaultproject.io)
 - [MongoDB Atlas Website](https://www.mongodb.com/cloud/atlas)
-- [Atlas MongoDB Secrets Docs](https://www.vaultproject.io/docs/secrets/atlasmongodb/index.html)
+- [MongoDB Atlas Secrets Docs](https://www.vaultproject.io/docs/secrets/atlasmongodb/index.html)
 - [Vault Github](https://www.github.com/hashicorp/vault)
 - [General Announcement List](https://groups.google.com/forum/#!forum/hashicorp-announce)
 - [Discussion List](https://groups.google.com/forum/#!forum/vault-tool)
@@ -25,31 +25,31 @@ directly via [security@mongodb.com](mailto:security@mongodb.com) or [open a tick
 
 This is a [Vault plugin](https://www.vaultproject.io/docs/internals/plugins.html)
 and is meant to work with Vault. This guide assumes you have already installed Vault
-and have a basic understanding of how Vault works. Otherwise, first read this guide on 
+and have a basic understanding of how Vault works. Otherwise, first read this guide on
 how to [get started with Vault](https://www.vaultproject.io/intro/getting-started/install.html).
 
 If you are using Vault 11.0.1 or above, this plugin is packaged with Vault
 and by default can be enabled by running:
  ```sh
- 
+
  $ vault secrets enable mongodbatlas
- 
+
  Success! Enabled the mongodbatlas secrets engine at: mongodbatlas/
- 
+
  ```
- 
- If you are testing this plugin in an earlier version of Vault or 
- want to develop, see the next section. 
+
+ If you are testing this plugin in an earlier version of Vault or
+ want to develop, see the next section.
 
 ## Developing
 
-If you wish to work on this plugin, you'll first need [Go](https://www.golang.org) 
+If you wish to work on this plugin, you'll first need [Go](https://www.golang.org)
 installed on your machine (whichever version is required by Vault).
 
 Make sure Go is properly installed, including setting up a [GOPATH](https://golang.org/doc/code.html#GOPATH).
 
-### Get Plugin 
-Clone this repository: 
+### Get Plugin
+Clone this repository:
 
 ```
 
@@ -111,14 +111,14 @@ $ vault secrets enable --plugin-name='mongodbatlas' --path="mongodbatlas" plugin
 
 ### Tests
 
-This plugin has both integration tests, and acceptance tests. 
+This plugin has both integration tests, and acceptance tests.
 
 The integration tests are run by `$ make test` and rather than firing real
 API calls, they fire API calls at a local test server that returns expected
 responses.
 
 The acceptance tests fire real API calls, and are located in `acceptance_test.go`.
-These should be run once as a final step before placing a PR. Please see 
+These should be run once as a final step before placing a PR. Please see
 `acceptance_test.go` to learn the environment variables that will need to be set.
 
 **Warning:** The acceptance tests create/destroy/modify *real resources*,
@@ -132,7 +132,7 @@ To run the acceptance tests, you need exporting the following environment variab
 
 
 
-To run the acceptance tests, after exporting the necessary environment variables, 
+To run the acceptance tests, after exporting the necessary environment variables,
 from the home directory run `go test`:
 
 ```sh

--- a/website/source/docs/secrets/atlasmongodb/index.html.md
+++ b/website/source/docs/secrets/atlasmongodb/index.html.md
@@ -11,12 +11,15 @@ description: |-
 
 The MongoDB Atlas Secrets Engine generates Database User credentials and Programmatic API keys. 
 This allows one to manage the lifecycle of these MongoDB Atlas secrets programmatically. The 
-created MongoDB Atlas secrets are time-based and are automatically revoked when the Vault lease expires, unless renewed.
+created MongoDB Atlas secrets are time-based and are automatically revoked when the Vault lease 
+expires, unless renewed.
 
 This Secrets Engine supports two different types of MongoDB Atlas Secrets:
 
-1. `database_user`: Vault will create a database user for each lease, each user has a defined role(s) that provide appropriate access to the project’s databases. The username and password is returned to the caller. To see more about database users visit: https://docs.atlas.mongodb.com/reference/api/database-users/
-2. `programmatic_api_key`: Vault will call
+1. `database_user`: Vault will create a database user for each lease, each user has a defined 
+    role(s) that provide appropriate access to the project’s databases. The username and password 
+    is returned to the caller. To see more about database users  visit [databaseUsers](https://docs.atlas.mongodb.com/reference/api/database-users/)
+2. `programmatic_api_key`: Vault will call) 
    [apiKeys](https://docs.atlas.mongodb.com/reference/api/apiKeys-orgs-create-one/)
    and return the public key, secret key.
 
@@ -26,7 +29,8 @@ Most Secrets Engines must be configured in advance before they can perform their
 functions. These steps are usually completed by an operator or configuration
 management tool.
 
-  ~> **Notice:** The following will be accurate after review and approval by Hashicorp, which is in progress. Until then follow the instructions in the [README developing section](./../../../../../README.md).
+  ~> **Notice:** The following will be accurate after review and approval by Hashicorp, which is in 
+    progress. Until then follow the instructions in the [README developing section](./../../../../../README.md).
 
 
 1. Enable the MongoDB Atlas Secrets Engine:
@@ -41,13 +45,13 @@ management tool.
 
 1. It's necessary to generate and configure an API key for your organization for the acceptance test to succeed. To grant programmatic access to an organization or project using only the [API](https://docs.atlas.mongodb.com/api/) you need to know:
 
-    1. The programmatic API key has two parts: a Public Key and a Private Key. To see more details on how to create a programmatic API key visit https://docs.atlas.mongodb.com/configure-api-access/#programmatic-api-keys.
+    1. The programmatic API key has two parts: a Public Key and a Private Key. To see more details on how to create a programmatic API key visit [apiKeys](https://docs.atlas.mongodb.com/configure-api-access/#programmatic-api-keys).
     
-    1. The programmatic API key must be granted roles sufficient for the acceptance test to succeed. The Organization Owner and Project Owner roles should be sufficient. You can see the available roles at https://docs.atlas.mongodb.com/reference/user-roles.
+    1. The programmatic API key must be granted roles sufficient for the acceptance test to succeed. The Organization Owner and Project Owner roles should be sufficient. You can see the available roles at [userRoles](https://docs.atlas.mongodb.com/reference/user-roles).
 
     1. You must [configure Atlas API Access](https://docs.atlas.mongodb.com/configure-api-access/) for your programmatic API key. You should allow API access for the IP address from which the acceptance test runs.
 
-1. Later you must configure the MongoDB credentials/keys created in the previous step, which Vault will use to communicate with MongoDB Atlas:
+1. You must configure the MongoDB credentials/keys created in the previous step, which Vault will use to communicate with MongoDB Atlas:
 
     ```bash
     $ vault write mongodbatlas/config/root \
@@ -63,8 +67,9 @@ management tool.
     your MongoDB Atlas root account credentials. Instead generate a dedicated Programmatic API key with appropriate roles.
 
 ## Database Users
-Configure a Vault role that maps to a set of permissions in MongoDB Atlas as well as 
-a MongoDB Atlas credentials/keys. When users generate credentials, they are generated
+
+Configures a Vault role that maps to a set of permissions in MongoDB Atlas as well as 
+a MongoDB Atlas credentials/keys. When Vault generates credentials, they are generated
 against this role. An example:
 
 ```bash
@@ -79,12 +84,13 @@ $ vault write mongodbatlas/roles/test \
       }]
     EOF
 ```
-~> **Notice:** Each user has a set of roles that provide access to the project’s databases. A user’s roles apply to all the clusters in the project: if two clusters have a products database and a user has a role granting read access on the products database, the user has that access on both clusters.
 
 This creates a role named "my-role". When users generate credentials against
 this role, Vault will create a database user and attach the specified roles to that
 database user mapped to the appropriate database/collection. Vault will then create 
-a username and password for the database user and return these credentials.
+an username and password for the database user and return the credentials.
+
+~> **Notice:** Each `database_user` has a set of roles that provide access to the project’s databases. A `database_user` roles apply to all the clusters in the project: if two clusters have a products database and a user has a role granting read access on the products database, the user has that access on both clusters.
 
 ```bash
 $ vault read mongodbatlas/creds/test
@@ -105,29 +111,25 @@ For more information on database user roles, please see
 
   One may grant programmatic access to MongoDB Atlas by creating a Programmatic API key with access to a organization and project(s).
   Programmatic API Keys:
-  - Have two parts, a public key and a private key
+  - Has two parts, a public key and a private key
   - Cannot be used to log into Atlas through the user interface
   - Must be granted appropriate roles to complete required tasks
   - Must belong to one organization, but may be granted access to any number of projects in that organization.
-  - May have an IP whitelist configured and some capabilities may require a whitelist to be configured (these are noted in the MongoDB Atlas API documentation).
-
-
+  - May have an IP whitelist configured and some capabilities may require a whitelist to be configured (these are noted in the MongoDB Atlas API documentation: [whitelist](https://docs.atlas.mongodb.com/reference/api/apiKeys-org-whitelist-create/)).
 
   Most Secrets Engines must be configured in advance before they can perform their
   functions. These steps are usually completed by an operator or configuration
   management tool.
 
-
   ~> **Notice:** Even though the path above is `atlas/config/root`, do not use
   your MongoDB Atlas root account credentials. Instead generate a dedicated user or
   role.
 
-
 1. Create a Vault role for a Programmatic API key by mapping a Programmatic API key role(s) to a organization or project in MongoDB Atlas.
-- If the key/role is for the MongoDB Atlas Organization level use organization_id with the appropriate Id and roles
-- If the key/role is for the MongoDB Atlas Project level use project_id with the appropriate Id and roles
+- If the key/role is for the MongoDB Atlas Organization level use `organization_id` with the appropriate ID and roles
+- If the key/role is for the MongoDB Atlas Project level use `project_id` with the appropriate ID and roles
 
-~> **Notice:** Programmatic API keys can belong to only one Organization but can belong to one or more Projects. An examples:
+~> **Notice:** Programmatic API keys can belong to only one Organization but also can belong to a project. An examples:
 
 ```bash
 $ vault write mongodbatlas/roles/test \
@@ -141,7 +143,7 @@ $ vault write mongodbatlas/roles/test \
     project_id=5cf5a45a9ccf6400e60981b6 \
     programmatic_key_roles=GROUP_DATA_ACCESS_READ_ONLY
 ```
-  ~> **Notice:**  The above examples creates two roles in Vault for Programmatic API keys. The first one is created at the [Organization](https://docs.mongodbatlas.mongodb.com/configure-api-access/) level with a role of ORG_MEMBER. The second example creates a Programmatic API key for the specified Project and grants access only GROUP_DATA_ACCESS_READ_ONLY.
+  ~> **Notice:**  The above examples creates two roles in Vault for Programmatic API keys. The former is created at the [Organization](https://docs.mongodbatlas.mongodb.com/configure-api-access/) level with a role of ORG_MEMBER. The later creates an API key for the specified Project and grants access only GROUP_DATA_ACCESS_READ_ONLY.
   
 You can attach one or more whitelist entries for the specific API Key as a follow:
 ```bash 
@@ -186,8 +188,8 @@ To verify you must run:
 
 ## TTL and Max TTL
 
-
 Every role has a time-to-live (TTL) and maximum time-to-live (Max TTL) which is used to validate the TTL.  When a role expires and it's not renewed, the role is automatically revoked. You can set the TTL and Max TTL for each created role.
+
 ```bash 
 $ vault write mongodbatlas/roles/test \
     credential_type=project_programmatic_api_key \
@@ -198,6 +200,7 @@ $ vault write mongodbatlas/roles/test \
 ```
 
 This creates a role that is attached to an associated lease:
+
 ```bash
 $ vault read mongodbatlas/creds/test
 
@@ -212,6 +215,7 @@ $ vault read mongodbatlas/creds/test
 ```
 
 You can verify the role that you have created before with:
+
 ```bash
 $ vault read mongodbatlas/roles/test   
 

--- a/website/source/docs/secrets/atlasmongodb/index.html.md
+++ b/website/source/docs/secrets/atlasmongodb/index.html.md
@@ -205,3 +205,5 @@ $ vault read atlas/roles/test
     roles                     n/a
     ttl                       2h0m0s
 ```
+
+ ~> **Notice:**  If you don't set the TTL and Max TTL when you are creating a role, the default lease will be established if it was previously configured in the `atlas/config/lease` path, but if it didn't set, the TTL will be set with 768h by default.

--- a/website/source/docs/secrets/atlasmongodb/index.html.md
+++ b/website/source/docs/secrets/atlasmongodb/index.html.md
@@ -16,12 +16,8 @@ expires, unless renewed.
 
 This Secrets Engine supports two different types of MongoDB Atlas Secrets:
 
-1. `database_user`: Vault will create a database user for each lease, each user has a defined 
-    role(s) that provide appropriate access to the project’s databases. The username and password 
-    is returned to the caller. To see more about database users  visit [databaseUsers](https://docs.atlas.mongodb.com/reference/api/database-users/)
-2. `programmatic_api_key`: Vault will call) 
-   [apiKeys](https://docs.atlas.mongodb.com/reference/api/apiKeys-orgs-create-one/)
-   and return the public key, secret key.
+1. `database_user`: Vault will create a database user for each lease, each database user has defined role(s) that provide appropriate access to the project’s databases/collections. The username and passwordis returned to the caller. To see more about database users visit the [MongoDB Atlas Database Users Documentation](https://docs.atlas.mongodb.com/reference/api/database-users/).
+2. `programmatic_api_key`: Vault will create a Programmatic API key for each lease, each key has defined role(s) that provide appropriate access to the defined MongoDB Atlas project or organization. The public and private key is returned to the caller. To see more about Programmatic API Keys visit the [Programmatic API Keys Doc](https://docs.atlas.mongodb.com/reference/api/database-users/).
 
 ## Setup
 
@@ -43,15 +39,13 @@ management tool.
     By default, the Secrets Engine will mount at the name of the engine. To
     enable the Secrets Engine at a different path, use the `-path` argument.
 
-1. It's necessary to generate and configure an API key for your organization for the acceptance test to succeed. To grant programmatic access to an organization or project using only the [API](https://docs.atlas.mongodb.com/api/) you need to know:
+1. It's necessary to generate and configure a MongoDB Atlas Programmatic API Key for your organization that has sufficient permissions to allow Vault to create other Programmatic API Keys.
 
-    1. The programmatic API key has two parts: a Public Key and a Private Key. To see more details on how to create a programmatic API key visit [apiKeys](https://docs.atlas.mongodb.com/configure-api-access/#programmatic-api-keys).
-    
-    1. The programmatic API key must be granted roles sufficient for the acceptance test to succeed. The Organization Owner and Project Owner roles should be sufficient. You can see the available roles at [userRoles](https://docs.atlas.mongodb.com/reference/user-roles).
+    In order to grant Vault programmatic access to an organization or project using only the [API](https://docs.atlas.mongodb.com/api/) you need to create a MongoDB Atlas Programmatic API Key with the appropriate roles if you have not already done so. A Programmatic API Key consists of a public and private key so ensure you have both. Regarding roles, the Organization Owner and Project Owner roles should be sufficient for most needs, however be sure to check what each roles grants in the [MongoDB Atlas Programmatic API Key User Roles documentation](https://docs.atlas.mongodb.com/reference/user-roles/). Also ensure you set an IP Whitelist when creating the key.
 
-    1. You must [configure Atlas API Access](https://docs.atlas.mongodb.com/configure-api-access/) for your programmatic API key. You should allow API access for the IP address from which the acceptance test runs.
+    For more detailed instructions on how to create a Programmatic API Key in the Atlas UI, including available roles, visit the [Programmatic API Key documenation](https://docs.atlas.mongodb.com/configure-api-access/#programmatic-api-keys).
 
-1. You must configure the MongoDB credentials/keys created in the previous step, which Vault will use to communicate with MongoDB Atlas:
+1. Once you have a MongoDB Atlas Programmatic Key pair, as created in the previous step, Vault can now be configured to use it with MongoDB Atlas:
 
     ```bash
     $ vault write mongodbatlas/config/root \
@@ -63,17 +57,14 @@ management tool.
     these credentials must be a superset of any policies which might be granted
     on API Keys. Since Vault uses the official [MongoDB Atlas Client](https://github.com/mongodb/go-client-mongodb-atlas), it will use the specified credentials. 
 
-    ~> **Notice:** Even though the path above is `mongodbatlas/config/root`, do not use
-    your MongoDB Atlas root account credentials. Instead generate a dedicated Programmatic API key with appropriate roles.
+    <!-- ~> **Notice:** Even though the path above is `mongodbatlas/config/root`, do not use
+    your MongoDB Atlas root account credentials. Instead generate a dedicated Programmatic API key with appropriate roles. -->
 
 ## Database Users
-
-Configures a Vault role that maps to a set of permissions in MongoDB Atlas as well as 
-a MongoDB Atlas credentials/keys. When Vault generates credentials, they are generated
-against this role. An example:
+The Database User, `database_user`, credential type creates a Vault role that maps a set of MongoDB Atlas database roles to a database/collection in the specified MongoDB Atlas project. An example:
 
 ```bash
-$ vault write mongodbatlas/roles/test \
+$ vault write mongodbatlas/roles/testDB \
     credential_type=database_user \
     project_id=5cf5a481ok7f6400e60981b6 \
     database_name=admin \
@@ -84,52 +75,45 @@ $ vault write mongodbatlas/roles/test \
       }]
     EOF
 ```
+~> **Notice:** Each user has a set of database roles that provide access to the Atlas project’s databases/collections. A user’s database roles apply to all the clusters in the project: if two clusters have a products database and a user has a database role granting read access on the products database, the user has that access on both clusters.
 
-This creates a role named "my-role". When users generate credentials against
-this role, Vault will create a database user and attach the specified roles to that
-database user mapped to the appropriate database/collection. Vault will then create 
-an username and password for the database user and return the credentials.
+This write creates a Vault role named "testDB" in the project specified by the project_id with an authentication database of admin. When users generate credentials against "testDB", Vault will create a database user in MongoDB Atlas project with the database role specified to the
+appropriate database/collection, in this case the database is testDB and the role granted is atlasAdmin. Vault will then return the username and password for the database user.
 
-~> **Notice:** Each `database_user` has a set of roles that provide access to the project’s databases. A `database_user` roles apply to all the clusters in the project: if two clusters have a products database and a user has a role granting read access on the products database, the user has that access on both clusters.
+Once the Vault role test is created it can be called to generate credentials. Note that the following read command uses the Vault default lease settings since they were not specified for the Vault role:
 
 ```bash
-$ vault read mongodbatlas/creds/test
+$ vault read mongodbatlas/creds/testDB
     Key                Value
     ---                -----
-    lease_id           mongodbatlas/creds/test/sZz3qvggwcULgERDqe9r151h
+    lease_id           mongodbatlas/creds/testDB/sZz3qvggwcULgERDqe9r151h
     lease_duration     20s
     lease_renewable    true
     password           A3mOyxvSnBpKG5sdID2iNR
-    username           vault-test-1563475091-2081
+    username           vault-testDB-1563475091-2081
 ```
-
-For more information on database user roles, please see
-[step two of the setup section](#Setup).
 
 ## Programmatic API Keys
 
+ The Programmatic API Key credential types, org_programmatic_api_key and project_programmatic_api_key, create a Vault role to generate a Programmatic API Key at either the MongoDB Atlas Organization or Project level with the appropriate role(s) for programmatic access.
 
-  One may grant programmatic access to MongoDB Atlas by creating a Programmatic API key with access to a organization and project(s).
   Programmatic API Keys:
   - Has two parts, a public key and a private key
   - Cannot be used to log into Atlas through the user interface
   - Must be granted appropriate roles to complete required tasks
-  - Must belong to one organization, or can be granted access a project within that organization.
-  - Can be configured to have API whitelist capabilities (these are noted in the MongoDB Atlas API documentation: [whitelist](https://docs.atlas.mongodb.com/reference/api/apiKeys-org-whitelist-create/)).
+  - Must belong to one organization, but may be granted access to any number of projects in that organization.
+  - May have an IP whitelist configured and some capabilities may require a whitelist to be configured (these are noted in the MongoDB Atlas API documentation).
 
-  Most Secrets Engines must be configured in advance before they can perform their
-  functions. These steps are usually completed by an operator or configuration
-  management tool.
 
-  ~> **Notice:** Even though the path above is `atlas/config/root`, do not use
-  your MongoDB Atlas root account credentials. Instead generate a dedicated user or
-  role.
+1. Create a Vault role for a MongoDB Atlas Programmatic API Key by mapping appropriate Key role(s) to the organization or project designated.
 
-1. Create a Vault role for a Programmatic API key by mapping a Programmatic API key role(s) to a organization or project in MongoDB Atlas.
-- If the key/role is for the MongoDB Atlas Organization level use `organization_id` with the appropriate ID and roles
-- If the key/role is for the MongoDB Atlas Project level use `project_id` with the appropriate ID and roles
+    - org_programmatic_api_key: Set organization_id to the MongoDB Atlas Organization Id with the appropriate [Organization Level Roles](https://docs.atlas.mongodb.com/reference/user-roles/#organization-roles).
 
-~> **Notice:** Programmatic API keys can belong to only one Organization but also can belong to a project. An examples:
+    - project_programmatic_api_key: Set project_id to the MongoDB Atlas Project Id with the appropriate [Project Level Roles](https://docs.atlas.mongodb.com/reference/user-roles/#project-roles).
+
+~> **Notice:** Programmatic API keys can belong to only one Organization but can belong to one or more Projects.
+
+Examples:
 
 ```bash
 $ vault write mongodbatlas/roles/test \
@@ -143,9 +127,13 @@ $ vault write mongodbatlas/roles/test \
     project_id=5cf5a45a9ccf6400e60981b6 \
     programmatic_key_roles=GROUP_DATA_ACCESS_READ_ONLY
 ```
-  ~> **Notice:**  The above examples creates two roles in Vault for Programmatic API keys. The former is created at the [Organization](https://docs.mongodbatlas.mongodb.com/configure-api-access/) level with a role of ORG_MEMBER. The later creates an API key for the specified Project and grants access only GROUP_DATA_ACCESS_READ_ONLY.
+
+In both of these examples Vault returns the public/private key pair generated.
+
+## Programmatic API Key Whitelist
+
+Programmatic API Key access can and should be limited with a IP Whitelist. In the following example both a CIDR block and IP address are added to the IP whitelist for Keys generated with this Vault role:
   
-You can attach one or more whitelist entries for the specific API Key as a follow:
 ```bash 
   $ vault write atlas/roles/test \
       credential_type=project_programmatic_api_key \
@@ -155,7 +143,8 @@ You can attach one or more whitelist entries for the specific API Key as a follo
       ip_addresses=192.168.1.3
 ```
 
-To verify you must run: 
+Verify the created Programmatic API Key Vault role has the added CIDR block and IP address by running:
+
 ```bash 
   $ vault read atlas/roles/test
   
@@ -165,13 +154,13 @@ To verify you must run:
     credential_type           project_programmatic_api_key
     database_name             n/a
     ip_addresses              [192.168.1.3]
+    max_ttl                   0s
     organization_id           n/a
     programmatic_key_roles    [GROUP_CLUSTER_MANAGER]
     project_id                5cf5a45a9ccf6400e60981b6
     roles                     n/a
+    ttl                       0s
 ```
-
-   This creates a set of Programmatic API keys that is attached to an [Organization](https://docs.atlas.mongodb.com/configure-api-access/#view-the-details-of-an-api-key-in-an-organization), if `project_id` is used, is attached to a [Project](https://docs.atlas.mongodb.com/configure-api-access/#manage-programmatic-access-to-a-project).
 
   ```bash 
     $ vault read mongodbatlas/creds/test
@@ -188,7 +177,9 @@ To verify you must run:
 
 ## TTL and Max TTL
 
-Each role can also have a time-to-live (TTL) and maximum time-to-live (Max TTL). When a credential expires and it's not renewed, it's automatically revoked. You can set the TTL and Max TTL for each role or globally using `config/lease`.
+Database User and Programmatic API Keys Vault role can also have a time-to-live (TTL) and maximum time-to-live (Max TTL). When a credential expires and it's not renewed, it's automatically revoked. You can set the TTL and Max TTL for each role or globally using config/lease.
+
+The following creates a Vault role "test" for a Project level Programmatic API key with a 2 hours time-to-live and a max time-to-live of 5 hours.
 
 ```bash 
 $ vault write mongodbatlas/roles/test \
@@ -199,7 +190,7 @@ $ vault write mongodbatlas/roles/test \
     max_ttl=5h
 ```
 
-This creates a credential that is attached to an associated lease:
+This then creates a credential with the lease time-to-live values:
 
 ```bash
 $ vault read mongodbatlas/creds/test
@@ -214,7 +205,7 @@ $ vault read mongodbatlas/creds/test
     public_key         klpruxce
 ```
 
-You can verify the role that you have created before with:
+You can verify the role that you have created with:
 
 ```bash
 $ vault read mongodbatlas/roles/test   
@@ -231,4 +222,4 @@ $ vault read mongodbatlas/roles/test
     ttl                       2h0m0s
 ```
 
- ~> **Notice:**  If you don't set the TTL and Max TTL when you are creating a role, the default lease will be established if it was previously configured in the `mongodbatlas/config/lease` path, but if it didn't set, the TTL will be set with using Vault's by default.
+ ~> **Notice:** If you don't set the TTL and Max TTL when you are creating a role the default lease will be used if it was previously configured in the `mongodbatlas/config/lease` path. If a default was not created for MongoDB Atlas then Vault's default will be used.

--- a/website/source/docs/secrets/atlasmongodb/index.html.md
+++ b/website/source/docs/secrets/atlasmongodb/index.html.md
@@ -139,15 +139,33 @@ $ vault write atlas/roles/test \
     project_id=5cf5a45a9ccf6400e60981b6 \
     programmatic_key_roles=GROUP_DATA_ACCESS_READ_ONLY
 ```
-
+  ~> **Notice:**  The above examples creates two roles in Vault for Programmatic API keys. The first one is created at the [Organization](https://docs.atlas.mongodb.com/configure-api-access/) level with a role of ORG_MEMBER. The second example creates a Programmatic API key for the specified Project and grants access only GROUP_DATA_ACCESS_READ_ONLY.
+  
+You can attach one or more whitelist entries for the specific API Key as a follow:
 ```bash 
-$ vault write atlas/roles/test \
-    credential_type=project_programmatic_api_key \
-    project_id=5cf5a45a9ccf6400e60981b6 \
-    programmatic_key_roles=GROUP_CLUSTER_MANAGER
+  $ vault write atlas/roles/test \
+      credential_type=project_programmatic_api_key \
+      project_id=5cf5a45a9ccf6400e60981b6 \
+      programmatic_key_roles=GROUP_CLUSTER_MANAGER \
+      cidr_blocks=192.168.1.3/32 \
+      ip_addresses=192.168.1.3
 ```
 
-  ~> **Notice:**  The above examples creates two roles in Vault for Programmatic API keys. The first one is created at the [Organization](https://docs.atlas.mongodb.com/configure-api-access/) level with a role of ORG_MEMBER. The second example creates a Programmatic API key for the specified Project and grants access only GROUP_DATA_ACCESS_READ_ONLY.
+To verify you must run: 
+```bash 
+  $ vault read atlas/roles/test
+  
+    Key                       Value
+    ---                       -----
+    cidr_blocks               [192.168.1.3/32]
+    credential_type           project_programmatic_api_key
+    database_name             n/a
+    ip_addrersses             [192.168.1.3]
+    organization_id           n/a
+    programmatic_key_roles    [GROUP_CLUSTER_MANAGER]
+    project_id                5cf5a45a9ccf6400e60981b6
+    roles                     n/a
+```
 
    This creates a set of Programmatic API keys that is attached to an [Organization](https://docs.atlas.mongodb.com/configure-api-access/#view-the-details-of-an-api-key-in-an-organization), if `project_id` is used, is attached to a [Project](https://docs.atlas.mongodb.com/configure-api-access/#manage-programmatic-access-to-a-project).
 
@@ -194,6 +212,7 @@ $ vault read atlas/creds/test
 You can verify the role that you have created before with:
 ```bash
 $ vault read atlas/roles/test   
+
     Key                       Value
     ---                       -----
     credential_type           org_programmatic_api_key

--- a/website/source/docs/secrets/atlasmongodb/index.html.md
+++ b/website/source/docs/secrets/atlasmongodb/index.html.md
@@ -62,41 +62,43 @@ management tool.
     ~> **Notice:** Even though the path above is `mongodbatlas/config/root`, do not use
     your MongoDB Atlas root account credentials. Instead generate a dedicated Programmatic API key with appropriate roles.
 
-1. Configure a Vault role that maps to a set of permissions in MongoDB Atlas as well as 
-   a MongoDB Atlas credentials/keys. When users generate credentials, they are generated
-   against this role. An example:
+## Database Users
+Configure a Vault role that maps to a set of permissions in MongoDB Atlas as well as 
+a MongoDB Atlas credentials/keys. When users generate credentials, they are generated
+against this role. An example:
 
-    ```bash
-    $ vault write mongodbatlas/roles/test \
-        credential_type=database_user \
-        project_id=5cf5a481ok7f6400e60981b6 \
-        database_name=admin \
-        roles=-<<EOF
-          [{
-            "databaseName": "admin",
-            "roleName": "atlasAdmin"
-          }]
-        EOF
-    ```
+```bash
+$ vault write mongodbatlas/roles/test \
+    credential_type=database_user \
+    project_id=5cf5a481ok7f6400e60981b6 \
+    database_name=admin \
+    roles=-<<EOF
+      [{
+        "databaseName": "admin",
+        "roleName": "atlasAdmin"
+      }]
+    EOF
+```
+~> **Notice:** Each user has a set of roles that provide access to the project’s databases. A user’s roles apply to all the clusters in the project: if two clusters have a products database and a user has a role granting read access on the products database, the user has that access on both clusters.
 
-    This creates a role named "my-role". When users generate credentials against
-    this role, Vault will create a database user and attach the specified roles to that
-    database user mapped to the appropriate database/collection. Vault will then create 
-    a username and password for the database user and return these credentials.
+This creates a role named "my-role". When users generate credentials against
+this role, Vault will create a database user and attach the specified roles to that
+database user mapped to the appropriate database/collection. Vault will then create 
+a username and password for the database user and return these credentials.
 
-    ```bash
-    $ vault read mongodbatlas/creds/test
-        Key                Value
-        ---                -----
-        lease_id           mongodbatlas/creds/test/sZz3qvggwcULgERDqe9r151h
-        lease_duration     20s
-        lease_renewable    true
-        password           A3mOyxvSnBpKG5sdID2iNR
-        username           vault-test-1563475091-2081
-    ```
+```bash
+$ vault read mongodbatlas/creds/test
+    Key                Value
+    ---                -----
+    lease_id           mongodbatlas/creds/test/sZz3qvggwcULgERDqe9r151h
+    lease_duration     20s
+    lease_renewable    true
+    password           A3mOyxvSnBpKG5sdID2iNR
+    username           vault-test-1563475091-2081
+```
 
-    For more information on database user roles, please see
-    [step two of the setup section](#Setup).
+For more information on database user roles, please see
+[step two of the setup section](#Setup).
 
 ## Programmatic API Keys
 
@@ -128,18 +130,18 @@ management tool.
 ~> **Notice:** Programmatic API keys can belong to only one Organization but can belong to one or more Projects. An examples:
 
 ```bash
-$ vault write atlas/roles/test \
+$ vault write mongodbatlas/roles/test \
     credential_type=org_programmatic_api_key \
     organization_id=5b23ff2f96e82130d0aaec13 \
     programmatic_key_roles=ORG_MEMBER
 ```
 ```bash 
-$ vault write atlas/roles/test \
+$ vault write mongodbatlas/roles/test \
     credential_type=project_programmatic_api_key \
     project_id=5cf5a45a9ccf6400e60981b6 \
     programmatic_key_roles=GROUP_DATA_ACCESS_READ_ONLY
 ```
-  ~> **Notice:**  The above examples creates two roles in Vault for Programmatic API keys. The first one is created at the [Organization](https://docs.atlas.mongodb.com/configure-api-access/) level with a role of ORG_MEMBER. The second example creates a Programmatic API key for the specified Project and grants access only GROUP_DATA_ACCESS_READ_ONLY.
+  ~> **Notice:**  The above examples creates two roles in Vault for Programmatic API keys. The first one is created at the [Organization](https://docs.mongodbatlas.mongodb.com/configure-api-access/) level with a role of ORG_MEMBER. The second example creates a Programmatic API key for the specified Project and grants access only GROUP_DATA_ACCESS_READ_ONLY.
   
 You can attach one or more whitelist entries for the specific API Key as a follow:
 ```bash 
@@ -170,11 +172,11 @@ To verify you must run:
    This creates a set of Programmatic API keys that is attached to an [Organization](https://docs.atlas.mongodb.com/configure-api-access/#view-the-details-of-an-api-key-in-an-organization), if `project_id` is used, is attached to a [Project](https://docs.atlas.mongodb.com/configure-api-access/#manage-programmatic-access-to-a-project).
 
   ```bash 
-    $ vault read atlas/creds/test
+    $ vault read mongodbatlas/creds/test
 
     Key                Value
     ---                -----
-    lease_id           atlas/creds/test/0fLBv1c2YDzPlJB1PwsRRKHR
+    lease_id           mongodbatlas/creds/test/0fLBv1c2YDzPlJB1PwsRRKHR
     lease_duration     20s
     lease_renewable    true
     description        vault-test-1563980947-1318
@@ -187,7 +189,7 @@ To verify you must run:
 
 Every role has a time-to-live (TTL) and maximum time-to-live (Max TTL) which is used to validate the TTL.  When a role expires and it's not renewed, the role is automatically revoked. You can set the TTL and Max TTL for each created role.
 ```bash 
-$ vault write atlas/roles/test \
+$ vault write mongodbatlas/roles/test \
     credential_type=project_programmatic_api_key \
     project_id=5cf5a45a9ccf6400e60981b6 \
     programmatic_key_roles=GROUP_DATA_ACCESS_READ_ONLY \
@@ -197,11 +199,11 @@ $ vault write atlas/roles/test \
 
 This creates a role that is attached to an associated lease:
 ```bash
-$ vault read atlas/creds/test
+$ vault read mongodbatlas/creds/test
 
     Key                Value
     ---                -----
-    lease_id           atlas/creds/test/0fLBv1c2YDzPlJB1PwsRRKHR
+    lease_id           mongodbatlas/creds/test/0fLBv1c2YDzPlJB1PwsRRKHR
     lease_duration     2h
     lease_renewable    true
     description        vault-test-1563980947-1318
@@ -211,7 +213,7 @@ $ vault read atlas/creds/test
 
 You can verify the role that you have created before with:
 ```bash
-$ vault read atlas/roles/test   
+$ vault read mongodbatlas/roles/test   
 
     Key                       Value
     ---                       -----
@@ -225,4 +227,4 @@ $ vault read atlas/roles/test
     ttl                       2h0m0s
 ```
 
- ~> **Notice:**  If you don't set the TTL and Max TTL when you are creating a role, the default lease will be established if it was previously configured in the `atlas/config/lease` path, but if it didn't set, the TTL will be set with 768h by default.
+ ~> **Notice:**  If you don't set the TTL and Max TTL when you are creating a role, the default lease will be established if it was previously configured in the `mongodbatlas/config/lease` path, but if it didn't set, the TTL will be set with 768h by default.

--- a/website/source/docs/secrets/atlasmongodb/index.html.md
+++ b/website/source/docs/secrets/atlasmongodb/index.html.md
@@ -114,8 +114,8 @@ For more information on database user roles, please see
   - Has two parts, a public key and a private key
   - Cannot be used to log into Atlas through the user interface
   - Must be granted appropriate roles to complete required tasks
-  - Must belong to one organization, but may be granted access to any number of projects in that organization.
-  - May have an IP whitelist configured and some capabilities may require a whitelist to be configured (these are noted in the MongoDB Atlas API documentation: [whitelist](https://docs.atlas.mongodb.com/reference/api/apiKeys-org-whitelist-create/)).
+  - Must belong to one organization, or can be granted access a project within that organization.
+  - Can be configured to have API whitelist capabilities (these are noted in the MongoDB Atlas API documentation: [whitelist](https://docs.atlas.mongodb.com/reference/api/apiKeys-org-whitelist-create/)).
 
   Most Secrets Engines must be configured in advance before they can perform their
   functions. These steps are usually completed by an operator or configuration
@@ -188,7 +188,7 @@ To verify you must run:
 
 ## TTL and Max TTL
 
-Every role has a time-to-live (TTL) and maximum time-to-live (Max TTL) which is used to validate the TTL.  When a role expires and it's not renewed, the role is automatically revoked. You can set the TTL and Max TTL for each created role.
+Each role can also have a time-to-live (TTL) and maximum time-to-live (Max TTL). When a credential expires and it's not renewed, it's automatically revoked. You can set the TTL and Max TTL for each role or globally using `config/lease`.
 
 ```bash 
 $ vault write mongodbatlas/roles/test \
@@ -199,7 +199,7 @@ $ vault write mongodbatlas/roles/test \
     max_ttl=5h
 ```
 
-This creates a role that is attached to an associated lease:
+This creates a credential that is attached to an associated lease:
 
 ```bash
 $ vault read mongodbatlas/creds/test
@@ -231,4 +231,4 @@ $ vault read mongodbatlas/roles/test
     ttl                       2h0m0s
 ```
 
- ~> **Notice:**  If you don't set the TTL and Max TTL when you are creating a role, the default lease will be established if it was previously configured in the `mongodbatlas/config/lease` path, but if it didn't set, the TTL will be set with 768h by default.
+ ~> **Notice:**  If you don't set the TTL and Max TTL when you are creating a role, the default lease will be established if it was previously configured in the `mongodbatlas/config/lease` path, but if it didn't set, the TTL will be set with using Vault's by default.

--- a/website/source/docs/secrets/atlasmongodb/index.html.md
+++ b/website/source/docs/secrets/atlasmongodb/index.html.md
@@ -4,28 +4,26 @@ page_title: "MongoDB Atlas - Secrets Engines"
 sidebar_title: "MongoDB Atlas"
 sidebar_current: "docs-secrets-atlasmongodb"
 description: |-
-  The MongoDB Atlas Secrets Engine for Vault generates MongoDB Database User Credentials and Programmatic API Keys dynamically.
+  The MongoDB Atlas Secrets Engine for Vault generates MongoDB Programmatic API Keys dynamically.
 ---
 
 # MongoDB Atlas Secrets Engine
 
-The MongoDB Atlas Secrets Engine generates Database User credentials and Programmatic API keys. 
-This allows one to manage the lifecycle of these MongoDB Atlas secrets programmatically. The 
-created MongoDB Atlas secrets are time-based and are automatically revoked when the Vault lease 
-expires, unless renewed.
+The MongoDB Atlas Secrets Engine generates Programmatic API keys. This allows one to manage the
+lifecycle of these MongoDB Atlas secrets programmatically. The created MongoDB Atlas secrets are
+time-based and are automatically revoked when the Vault lease expires, unless renewed.
 
-This Secrets Engine supports two different types of MongoDB Atlas Secrets:
-
-1. `database_user`: Vault will create a database user for each lease, each database user has defined role(s) that provide appropriate access to the project’s databases/collections. The username and passwordis returned to the caller. To see more about database users visit the [MongoDB Atlas Database Users Documentation](https://docs.atlas.mongodb.com/reference/api/database-users/).
-2. `programmatic_api_key`: Vault will create a Programmatic API key for each lease, each key has defined role(s) that provide appropriate access to the defined MongoDB Atlas project or organization. The public and private key is returned to the caller. To see more about Programmatic API Keys visit the [Programmatic API Keys Doc](https://docs.atlas.mongodb.com/reference/api/database-users/).
+This Secrets Engine supports the creation of Programmatic API keys Vault will create a Programmatic
+API key for each lease, each key has defined role(s) that provide appropriate access to the defined
+MongoDB Atlas project or organization. The public and private key is returned to the caller. To see
+more about Programmatic API Keys visit the [Programmatic API Keys Doc](https://docs.atlas.mongodb.com/reference/api/apiKeys/).
 
 ## Setup
 
-Most Secrets Engines must be configured in advance before they can perform their
-functions. These steps are usually completed by an operator or configuration
-management tool.
+Most Secrets Engines must be configured in advance before they can perform their functions. These
+steps are usually completed by an operator or configuration management tool.
 
-  ~> **Notice:** The following will be accurate after review and approval by Hashicorp, which is in 
+  ~> **Notice:** The following will be accurate after review and approval by Hashicorp, which is in
     progress. Until then follow the instructions in the [README developing section](./../../../../../README.md).
 
 
@@ -39,13 +37,22 @@ management tool.
     By default, the Secrets Engine will mount at the name of the engine. To
     enable the Secrets Engine at a different path, use the `-path` argument.
 
-1. It's necessary to generate and configure a MongoDB Atlas Programmatic API Key for your organization that has sufficient permissions to allow Vault to create other Programmatic API Keys.
+1. It's necessary to generate and configure a MongoDB Atlas Programmatic API Key for your organization
+   that has sufficient permissions to allow Vault to create other Programmatic API Keys.
 
-    In order to grant Vault programmatic access to an organization or project using only the [API](https://docs.atlas.mongodb.com/api/) you need to create a MongoDB Atlas Programmatic API Key with the appropriate roles if you have not already done so. A Programmatic API Key consists of a public and private key so ensure you have both. Regarding roles, the Organization Owner and Project Owner roles should be sufficient for most needs, however be sure to check what each roles grants in the [MongoDB Atlas Programmatic API Key User Roles documentation](https://docs.atlas.mongodb.com/reference/user-roles/). Also ensure you set an IP Whitelist when creating the key.
+    In order to grant Vault programmatic access to an organization or project using only the
+    [API](https://docs.atlas.mongodb.com/api/) you need to create a MongoDB Atlas Programmatic API
+    Key with the appropriate roles if you have not already done so. A Programmatic API Key consists
+    of a public and private key so ensure you have both. Regarding roles, the Organization Owner and
+    Project Owner roles should be sufficient for most needs, however be sure to check what each roles
+    grants in the [MongoDB Atlas Programmatic API Key User Roles documentation](https://docs.atlas.mongodb.com/reference/user-roles/).
+    Also ensure you set an IP Whitelist when creating the key.
 
-    For more detailed instructions on how to create a Programmatic API Key in the Atlas UI, including available roles, visit the [Programmatic API Key documenation](https://docs.atlas.mongodb.com/configure-api-access/#programmatic-api-keys).
+    For more detailed instructions on how to create a Programmatic API Key in the Atlas UI, including
+    available roles, visit the [Programmatic API Key documenation](https://docs.atlas.mongodb.com/configure-api-access/#programmatic-api-keys).
 
-1. Once you have a MongoDB Atlas Programmatic Key pair, as created in the previous step, Vault can now be configured to use it with MongoDB Atlas:
+1. Once you have a MongoDB Atlas Programmatic Key pair, as created in the previous step, Vault can now
+   be configured to use it with MongoDB Atlas:
 
     ```bash
     $ vault write mongodbatlas/config/root \
@@ -55,61 +62,38 @@ management tool.
 
     Internally, Vault will connect to MongoDB Atlas using these credentials. As such,
     these credentials must be a superset of any policies which might be granted
-    on API Keys. Since Vault uses the official [MongoDB Atlas Client](https://github.com/mongodb/go-client-mongodb-atlas), it will use the specified credentials. 
+    on API Keys. Since Vault uses the official [MongoDB Atlas Client](https://github.com/mongodb/go-client-mongodb-atlas),
+    it will use the specified credentials.
 
     <!-- ~> **Notice:** Even though the path above is `mongodbatlas/config/root`, do not use
     your MongoDB Atlas root account credentials. Instead generate a dedicated Programmatic API key with appropriate roles. -->
 
-## Database Users
-The Database User, `database_user`, credential type creates a Vault role that maps a set of MongoDB Atlas database roles to a database/collection in the specified MongoDB Atlas project. An example:
-
-```bash
-$ vault write mongodbatlas/roles/testDB \
-    credential_type=database_user \
-    project_id=5cf5a481ok7f6400e60981b6 \
-    database_name=admin \
-    roles=-<<EOF
-      [{
-        "databaseName": "admin",
-        "roleName": "atlasAdmin"
-      }]
-    EOF
-```
-~> **Notice:** Each user has a set of database roles that provide access to the Atlas project’s databases/collections. A user’s database roles apply to all the clusters in the project: if two clusters have a products database and a user has a database role granting read access on the products database, the user has that access on both clusters.
-
-This write creates a Vault role named "testDB" in the project specified by the project_id with an authentication database of admin. When users generate credentials against "testDB", Vault will create a database user in MongoDB Atlas project with the database role specified to the
-appropriate database/collection, in this case the database is testDB and the role granted is atlasAdmin. Vault will then return the username and password for the database user.
-
-Once the Vault role test is created it can be called to generate credentials. Note that the following read command uses the Vault default lease settings since they were not specified for the Vault role:
-
-```bash
-$ vault read mongodbatlas/creds/testDB
-    Key                Value
-    ---                -----
-    lease_id           mongodbatlas/creds/testDB/sZz3qvggwcULgERDqe9r151h
-    lease_duration     20s
-    lease_renewable    true
-    password           A3mOyxvSnBpKG5sdID2iNR
-    username           vault-testDB-1563475091-2081
-```
 
 ## Programmatic API Keys
 
- The Programmatic API Key credential types, org_programmatic_api_key and project_programmatic_api_key, create a Vault role to generate a Programmatic API Key at either the MongoDB Atlas Organization or Project level with the appropriate role(s) for programmatic access.
+The Programmatic API Key credential types, create a Vault role to generate a Programmatic API Key at
+either the MongoDB Atlas Organization or Project level with the appropriate role(s) for programmatic access.
 
   Programmatic API Keys:
   - Has two parts, a public key and a private key
   - Cannot be used to log into Atlas through the user interface
   - Must be granted appropriate roles to complete required tasks
-  - Must belong to one organization, but may be granted access to any number of projects in that organization.
-  - May have an IP whitelist configured and some capabilities may require a whitelist to be configured (these are noted in the MongoDB Atlas API documentation).
+  - Must belong to one organization, but may be granted access to any number of
+    projects in that organization.
+  - May have an IP whitelist configured and some capabilities may require a
+    whitelist to be configured (these are noted in the MongoDB Atlas API
+    documentation).
 
 
-1. Create a Vault role for a MongoDB Atlas Programmatic API Key by mapping appropriate Key role(s) to the organization or project designated.
+1. Create a Vault role for a MongoDB Atlas Programmatic API Key by mapping appropriate arguments to the
+   organization or project designated.
 
-    - org_programmatic_api_key: Set organization_id to the MongoDB Atlas Organization Id with the appropriate [Organization Level Roles](https://docs.atlas.mongodb.com/reference/user-roles/#organization-roles).
-
-    - project_programmatic_api_key: Set project_id to the MongoDB Atlas Project Id with the appropriate [Project Level Roles](https://docs.atlas.mongodb.com/reference/user-roles/#project-roles).
+    - Organization API Key: Set `organization_id` argument with the appropriate
+    [Organization Level Roles](https://docs.atlas.mongodb.com/reference/user-roles/#organization-roles).
+    - Project API Key: Set `project_id` with the appropriate [Project Level Roles](https://docs.atlas.mongodb.com/reference/user-roles/#project-roles).
+  - Create a Organization Key and Assign to a project: creates an Organization
+    key and [Assigns]() it to a project, for this `project_id` and `organization_id`
+    must be set, with the appropiate [Project Level Roles](https://docs.atlas.mongodb.com/reference/user-roles/#project-roles).
 
 ~> **Notice:** Programmatic API keys can belong to only one Organization but can belong to one or more Projects.
 
@@ -117,52 +101,48 @@ Examples:
 
 ```bash
 $ vault write mongodbatlas/roles/test \
-    credential_type=org_programmatic_api_key \
     organization_id=5b23ff2f96e82130d0aaec13 \
-    programmatic_key_roles=ORG_MEMBER
+    roles=ORG_MEMBER
 ```
-```bash 
+```bash
 $ vault write mongodbatlas/roles/test \
-    credential_type=project_programmatic_api_key \
     project_id=5cf5a45a9ccf6400e60981b6 \
-    programmatic_key_roles=GROUP_DATA_ACCESS_READ_ONLY
+    roles=GROUP_DATA_ACCESS_READ_ONLY
 ```
 
 In both of these examples Vault returns the public/private key pair generated.
 
 ## Programmatic API Key Whitelist
 
-Programmatic API Key access can and should be limited with a IP Whitelist. In the following example both a CIDR block and IP address are added to the IP whitelist for Keys generated with this Vault role:
-  
-```bash 
+Programmatic API Key access can and should be limited with a IP Whitelist. In the following example both a CIDR
+block and IP address are added to the IP whitelist for Keys generated with this Vault role:
+
+```bash
   $ vault write atlas/roles/test \
-      credential_type=project_programmatic_api_key \
       project_id=5cf5a45a9ccf6400e60981b6 \
-      programmatic_key_roles=GROUP_CLUSTER_MANAGER \
+      roles=GROUP_CLUSTER_MANAGER \
       cidr_blocks=192.168.1.3/32 \
       ip_addresses=192.168.1.3
 ```
 
 Verify the created Programmatic API Key Vault role has the added CIDR block and IP address by running:
 
-```bash 
+```bash
   $ vault read atlas/roles/test
-  
+
     Key                       Value
     ---                       -----
     cidr_blocks               [192.168.1.3/32]
-    credential_type           project_programmatic_api_key
-    database_name             n/a
     ip_addresses              [192.168.1.3]
     max_ttl                   0s
     organization_id           n/a
-    programmatic_key_roles    [GROUP_CLUSTER_MANAGER]
+    roles                     [GROUP_CLUSTER_MANAGER]
     project_id                5cf5a45a9ccf6400e60981b6
     roles                     n/a
     ttl                       0s
 ```
 
-  ```bash 
+  ```bash
     $ vault read mongodbatlas/creds/test
 
     Key                Value
@@ -177,15 +157,17 @@ Verify the created Programmatic API Key Vault role has the added CIDR block and 
 
 ## TTL and Max TTL
 
-Database User and Programmatic API Keys Vault role can also have a time-to-live (TTL) and maximum time-to-live (Max TTL). When a credential expires and it's not renewed, it's automatically revoked. You can set the TTL and Max TTL for each role or globally using config/lease.
+Database User and Programmatic API Keys Vault role can also have a time-to-live (TTL) and maximum time-to-live (Max TTL).
+When a credential expires and it's not renewed, it's automatically revoked. You can set the TTL and Max TTL for each role
+or globally using config/lease.
 
-The following creates a Vault role "test" for a Project level Programmatic API key with a 2 hours time-to-live and a max time-to-live of 5 hours.
+The following creates a Vault role "test" for a Project level Programmatic API key with a 2 hours time-to-live and a
+max time-to-live of 5 hours.
 
-```bash 
+```bash
 $ vault write mongodbatlas/roles/test \
-    credential_type=project_programmatic_api_key \
     project_id=5cf5a45a9ccf6400e60981b6 \
-    programmatic_key_roles=GROUP_DATA_ACCESS_READ_ONLY \
+    roles=GROUP_DATA_ACCESS_READ_ONLY \
     ttl=2h \
     max_ttl=5h
 ```
@@ -208,18 +190,18 @@ $ vault read mongodbatlas/creds/test
 You can verify the role that you have created with:
 
 ```bash
-$ vault read mongodbatlas/roles/test   
+$ vault read mongodbatlas/roles/test
 
     Key                       Value
     ---                       -----
-    credential_type           org_programmatic_api_key
-    database_name             n/a
     max_ttl                   5h0m0s
     organization_id           5b71ff2f96e82120d0aaec14
-    programmatic_key_roles    [GROUP_DATA_ACCESS_READ_ONLY]
+    roles                     [GROUP_DATA_ACCESS_READ_ONLY]
     project_id                5cf5a45a9ccf6400e60981b6
     roles                     n/a
     ttl                       2h0m0s
 ```
 
- ~> **Notice:** If you don't set the TTL and Max TTL when you are creating a role the default lease will be used if it was previously configured in the `mongodbatlas/config/lease` path. If a default was not created for MongoDB Atlas then Vault's default will be used.
+  ~> **Notice:** If you don't set the TTL and Max TTL when you are creating a role the default lease will be used if it
+  was previously configured in the `mongodbatlas/config/lease` path. If a default was not created for MongoDB Atlas then
+  Vault's default will be used.

--- a/website/source/docs/secrets/atlasmongodb/index.html.md
+++ b/website/source/docs/secrets/atlasmongodb/index.html.md
@@ -151,7 +151,7 @@ $ vault write atlas/roles/test \
 
    This creates a set of Programmatic API keys that is attached to an [Organization](https://docs.atlas.mongodb.com/configure-api-access/#view-the-details-of-an-api-key-in-an-organization), if `project_id` is used, is attached to a [Project](https://docs.atlas.mongodb.com/configure-api-access/#manage-programmatic-access-to-a-project).
 
-    ```bash 
+  ```bash 
     $ vault read atlas/creds/test
 
     Key                Value
@@ -162,5 +162,46 @@ $ vault write atlas/roles/test \
     description        vault-test-1563980947-1318
     private_key        905ae89e-6ee8-40rd-ab12-613t8e3fe836
     public_key         klpruxce
-    ```
+  ```
 
+## TTL and Max TTL
+
+
+Every role has a time-to-live (TTL) and maximum time-to-live (Max TTL) which is used to validate the TTL.  When a role expires and it's not renewed, the role is automatically revoked. You can set the TTL and Max TTL for each created role.
+```bash 
+$ vault write atlas/roles/test \
+    credential_type=project_programmatic_api_key \
+    project_id=5cf5a45a9ccf6400e60981b6 \
+    programmatic_key_roles=GROUP_DATA_ACCESS_READ_ONLY \
+    ttl=2h \
+    max_ttl=5h
+```
+
+This creates a role that is attached to an associated lease:
+```bash
+$ vault read atlas/creds/test
+
+    Key                Value
+    ---                -----
+    lease_id           atlas/creds/test/0fLBv1c2YDzPlJB1PwsRRKHR
+    lease_duration     2h
+    lease_renewable    true
+    description        vault-test-1563980947-1318
+    private_key        905ae89e-6ee8-40rd-ab12-613t8e3fe836
+    public_key         klpruxce
+```
+
+You can verify the role that you have created before with:
+```bash
+$ vault read atlas/roles/test   
+    Key                       Value
+    ---                       -----
+    credential_type           org_programmatic_api_key
+    database_name             n/a
+    max_ttl                   5h0m0s
+    organization_id           5b71ff2f96e82120d0aaec14
+    programmatic_key_roles    [GROUP_DATA_ACCESS_READ_ONLY]
+    project_id                5cf5a45a9ccf6400e60981b6
+    roles                     n/a
+    ttl                       2h0m0s
+```

--- a/website/source/docs/secrets/atlasmongodb/index.html.md
+++ b/website/source/docs/secrets/atlasmongodb/index.html.md
@@ -162,7 +162,7 @@ To verify you must run:
     cidr_blocks               [192.168.1.3/32]
     credential_type           project_programmatic_api_key
     database_name             n/a
-    ip_addrersses             [192.168.1.3]
+    ip_addresses              [192.168.1.3]
     organization_id           n/a
     programmatic_key_roles    [GROUP_CLUSTER_MANAGER]
     project_id                5cf5a45a9ccf6400e60981b6


### PR DESCRIPTION
- Add TTL example

```bash 
$ vault write atlas/roles/test \
    credential_type=project_programmatic_api_key \
    project_id=5cf5a45a9ccf6400e60981b6 \
    programmatic_key_roles=GROUP_DATA_ACCESS_READ_ONLY \
    ttl=2h \
    max_ttl=5h
```

```bash
$ vault read atlas/creds/test

    Key                Value
    ---                -----
    lease_id           atlas/creds/test/0fLBv1c2YDzPlJB1PwsRRKHR
    lease_duration     2h
    lease_renewable    true
    description        vault-test-1563980947-1318
    private_key        905ae89e-6ee8-40rd-ab12-613t8e3fe836
    public_key         klpruxce
```

```bash
$ vault read atlas/roles/test   
    Key                       Value
    ---                       -----
    credential_type           org_programmatic_api_key
    database_name             n/a
    max_ttl                   5h0m0s
    organization_id           5b71ff2f96e82120d0aaec14
    programmatic_key_roles    [GROUP_DATA_ACCESS_READ_ONLY]
    project_id                5cf5a45a9ccf6400e60981b6
    roles                     n/a
    ttl                       2h0m0s
```
closes #8